### PR TITLE
Added high level function for DNS record API + other tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
-/target
-Cargo.lock
-ovh.conf
+/.idea/
+/target/
+/Cargo.lock
+/ovh.conf

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,17 +9,20 @@ keywords = ["ovh", "api"]
 categories = ["api-bindings"]
 repository = "https://github.com/MicroJoe/rust-ovh"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
-reqwest = { version = "0.11", default-features = false, features = ["rustls-tls", "json"] }
-tokio = { version = "1", features = ["full"] }
+reqwest = { version = "0.12", default-features = false, features = [
+    "charset", "http2", "macos-system-configuration", # keep default-features except for default-tls
+    "rustls-tls", # use rustls-tls instead of default-tls to not be depedent on OpenSSL at runtime
+    "json" # required to deserialize request
+]}
+tokio = "1"
 futures = "0.3"
 sha1 = { version = "0.6", features = ["std"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-phf = { version = "0.10", features = ["macros"] }
-configparser = "2"
+phf = { version = "0.11", features = ["macros"] }
+configparser = "3"
 
 [dev-dependencies]
-clap = "3"
+clap = { version = "4", features = ["derive"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/MicroJoe/rust-ovh"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-reqwest = { version = "0.11", features = ["json"] }
+reqwest = { version = "0.11", default-features = false, features = ["rustls-tls", "json"] }
 tokio = { version = "1", features = ["full"] }
 futures = "0.3"
 sha1 = { version = "0.6.0", features = ["std"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,12 @@ repository = "https://github.com/MicroJoe/rust-ovh"
 [dependencies]
 reqwest = { version = "0.12", default-features = false, features = [
     "charset", "http2", "macos-system-configuration", # keep default-features except for default-tls
-    "rustls-tls", # use rustls-tls instead of default-tls to not be depedent on OpenSSL at runtime
+    "rustls-tls", # use rustls-tls instead of default-tls to not be dependent on OpenSSL at runtime
     "json" # required to deserialize request
 ]}
 tokio = "1"
 futures = "0.3"
-sha1 = { version = "0.6", features = ["std"] }
+sha1_smol = { version = "1", features = ["std"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 phf = { version = "0.11", features = ["macros"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,11 +15,11 @@ repository = "https://github.com/MicroJoe/rust-ovh"
 reqwest = { version = "0.11", default-features = false, features = ["rustls-tls", "json"] }
 tokio = { version = "1", features = ["full"] }
 futures = "0.3"
-sha1 = { version = "0.6.0", features = ["std"] }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+sha1 = { version = "0.6", features = ["std"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 phf = { version = "0.10", features = ["macros"] }
-configparser = "2.1.0"
+configparser = "2"
 
 [dev-dependencies]
-clap = "3.0.0-beta.4"
+clap = "3"

--- a/examples/email-redir/main.rs
+++ b/examples/email-redir/main.rs
@@ -1,26 +1,26 @@
 use ovh::client::OvhClient;
 use ovh::email_redir::OvhMailRedir;
 
-use clap::Clap;
+use clap::Parser;
 
 /// A simple CLI tool to handle email redirections using OVH's REST API
-#[derive(Clap)]
+#[derive(Parser)]
 struct Opts {
     /// File containing API credentials
-    #[clap(short, long, default_value = "ovh.conf")]
+    #[arg(short, long, default_value = "ovh.conf")]
     config: String,
 
     #[clap(subcommand)]
     subcmd: SubCommand,
 }
 
-#[derive(Clap)]
+#[derive(Parser)]
 struct ListArgs {
     /// Domain to list the aliases from
     domain: String,
 }
 
-#[derive(Clap)]
+#[derive(Parser)]
 struct CreateArgs {
     /// Domain to create the alias to
     domain: String,
@@ -36,14 +36,14 @@ struct CreateArgs {
     local_copy: bool,
 }
 
-#[derive(Clap)]
+#[derive(Parser)]
 struct DeleteArgs {
     domain: String,
 
     id: String,
 }
 
-#[derive(Clap)]
+#[derive(Parser)]
 enum SubCommand {
     /// List all redirections for a given domain
     List(ListArgs),
@@ -59,7 +59,7 @@ enum SubCommand {
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let opts: Opts = Opts::parse();
 
-    let c = OvhClient::from_conf(&opts.config)?;
+    let c = OvhClient::from_conf(&opts.config).await?;
 
     match opts.subcmd {
         SubCommand::List(a) => {

--- a/src/client.rs
+++ b/src/client.rs
@@ -46,44 +46,50 @@ pub struct OvhClient {
     application_secret: String,
     consumer_key: String,
     client: reqwest::Client,
+    time_delta: i64,
 }
 
 impl OvhClient {
     /// Creates a new client from scratch.
     ///
-    /// ```
+    /// This function will perform an API call to get the server time.
+    ///
+    /// ```no_run
     /// use ovh::client::OvhClient;
     ///
     /// let app_key = "my_app_key";
     /// let app_secret = "my_app_secret";
     /// let consumer_key = "my_consumer_key";
     ///
-    /// let client = OvhClient::new("ovh-eu", app_key, app_secret, consumer_key);
-    /// assert!(client.is_some());
-    ///
-    /// let client = OvhClient::new("wrong-endpoint", app_key, app_secret, consumer_key);
-    /// assert!(client.is_none());
+    /// let client = OvhClient::new("ovh-eu", app_key, app_secret, consumer_key).await.unwrap();
     /// ```
-    pub fn new(
+    pub async fn new(
         endpoint: &str,
         application_key: &str,
         application_secret: &str,
         consumer_key: &str,
-    ) -> Option<OvhClient> {
-        let endpoint = ENDPOINTS.get(endpoint)?;
+    ) -> Result<OvhClient> {
+        let endpoint = ENDPOINTS.get(endpoint).ok_or("unknown endpoint")?;
         let application_key = application_key.into();
         let application_secret = application_secret.into();
         let consumer_key = consumer_key.into();
 
         let client = reqwest::Client::new();
 
-        Some(OvhClient {
+        let mut ovh_client = OvhClient {
             endpoint,
             application_key,
             application_secret,
             consumer_key,
             client,
-        })
+            time_delta: 0,
+        };
+
+        let server_time: i64 = ovh_client.get_noauth("/auth/time").await?.text().await?.parse()?;
+        let now: i64 = now().try_into()?;
+        ovh_client.time_delta = now - server_time;
+
+        Ok(ovh_client)
     }
 
     /// Creates a new client from a configuration file.
@@ -105,7 +111,9 @@ impl OvhClient {
     /// ; with a single consumer key.
     /// ;consumer_key=my_consumer_key
     /// ```
-    pub fn from_conf<T>(path: T) -> Result<Self>
+    ///
+    /// This function will perform an API call to get the server time.
+    pub async fn from_conf<T>(path: T) -> Result<Self>
     where
         T: AsRef<Path>,
     {
@@ -125,15 +133,12 @@ impl OvhClient {
             .get(&endpoint, "consumer_key")
             .ok_or("missing key `consumer_key`")?;
 
-        let c = Self::new(
+        Self::new(
             &endpoint,
             &application_key,
             &application_secret,
             &consumer_key,
-        )
-        .ok_or("failed to create client")?;
-
-        Ok(c)
+        ).await
     }
 
     fn signature(&self, url: &str, timestamp: &str, method: &str, body: &str) -> String {
@@ -153,18 +158,15 @@ impl OvhClient {
         format!("{}{}", &self.endpoint, path)
     }
 
-    /// Retrieves the time delta between the local machine and the API server.
+    /// Retrieves the time delta in seconds between the local machine and the API server
+    /// (machine_unix_epoch - server_unix_epoch).
     ///
-    /// This method will perform a request to the API server to get its
-    /// local time, and then subtract it from the local time of the machine.
-    /// The result is a time delta value, is seconds.
-    pub async fn time_delta(&self) -> Result<i64> {
-        Ok(0)
-        /* FIXME What is the point of that? (see https://github.com/MicroJoe/rust-ovh/issues/1)
-        let server_time: u64 = self.get_noauth("/auth/time").await?.text().await?.parse()?;
-        let delta = (now() - server_time).try_into()?;
-        Ok(delta)
-        */
+    /// The delta was determined by performing a request to the API server to get its
+    /// time, and then subtract it from the local machine time.
+    /// The result is a time delta value, is seconds, that shouldn't be far from 0 if the local
+    /// clock is correctly synchronized.
+    pub fn time_delta(&self) -> i64 {
+        self.time_delta
     }
 
     fn default_headers(&self) -> reqwest::header::HeaderMap {
@@ -186,9 +188,8 @@ impl OvhClient {
             );
         }
 
-        let time_delta = self.time_delta().await?;
         let now: i64 = now().try_into()?;
-        let timestamp = now + time_delta;
+        let timestamp = now + self.time_delta;
         let timestamp = timestamp.to_string();
 
         let signature = self.signature(url, &timestamp, method, body);

--- a/src/client.rs
+++ b/src/client.rs
@@ -57,11 +57,14 @@ impl OvhClient {
     /// ```no_run
     /// use ovh::client::OvhClient;
     ///
-    /// let app_key = "my_app_key";
-    /// let app_secret = "my_app_secret";
-    /// let consumer_key = "my_consumer_key";
+    /// #[tokio::main]
+    /// async fn main () {
+    ///     let app_key = "my_app_key";
+    ///     let app_secret = "my_app_secret";
+    ///     let consumer_key = "my_consumer_key";
     ///
-    /// let client = OvhClient::new("ovh-eu", app_key, app_secret, consumer_key).await.unwrap();
+    ///     let client = OvhClient::new("ovh-eu", app_key, app_secret, consumer_key).await.unwrap();
+    /// }
     /// ```
     pub async fn new(
         endpoint: &str,

--- a/src/client.rs
+++ b/src/client.rs
@@ -4,6 +4,7 @@ use configparser::ini::Ini;
 use reqwest::{header::HeaderMap, Response};
 use serde::Serialize;
 use std::{convert::TryInto, path::Path, result, time::{SystemTime, UNIX_EPOCH}};
+use sha1_smol::Sha1;
 
 // Private data
 
@@ -153,7 +154,7 @@ impl OvhClient {
             body,
             timestamp,
         ];
-        let sha = sha1::Sha1::from(values.join("+")).hexdigest();
+        let sha = Sha1::from(values.join("+")).hexdigest();
         format!("$1${}", sha)
     }
 

--- a/src/dns_record.rs
+++ b/src/dns_record.rs
@@ -1,11 +1,9 @@
 //! High-level access to the DNS records API.
 
 use core::fmt;
-use std::collections::HashMap;
 use std::fmt::Display;
 
 use futures::future;
-use reqwest::Response;
 use serde::{Deserialize, Serialize};
 
 use crate::client::OvhClient;

--- a/src/dns_record.rs
+++ b/src/dns_record.rs
@@ -1,0 +1,119 @@
+//! High-level access to the DNS records API.
+
+use core::fmt;
+use std::fmt::Display;
+
+use futures::future;
+use reqwest::Response;
+use serde::{Deserialize, Serialize};
+
+use crate::client::OvhClient;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub enum DnsRecordType {
+    A,
+    AAAA,
+    CAA,
+    CNAME,
+    DKIM,
+    DMARC,
+    DNAME,
+    LOC,
+    MX,
+    NAPTR,
+    NS,
+    PTR,
+    SPF,
+    SRV,
+    SSHFP,
+    TLSA,
+    TXT,
+}
+
+/// Structure representing a single DNS record.
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OvhDnsRecord {
+    /// The internal name of the zone
+    pub zone: String,
+    /// Resource record Name
+    pub field_type: DnsRecordType,
+    /// Resource record subdomain
+    pub sub_domain: Option<String>,
+    /// Resource record target
+    pub target: String,
+    /// Resource record ttl (positive 32 bit signed integer, see: https://www.rfc-editor.org/rfc/rfc2181#section-8)
+    pub ttl: Option<i32>,
+}
+
+impl OvhDnsRecord {
+    /// Retrieves a DNS record
+    async fn get_record(
+        client: &OvhClient,
+        zone_name: &str,
+        id: u64,
+    ) -> Result<OvhDnsRecord, Box<dyn std::error::Error>> {
+        let mut record: OvhDnsRecord = client
+            .get(&format!("/domain/zone/{}/record/{}", zone_name, id))
+            .await?
+            .json()
+            .await?;
+
+        // normalize sub_domain
+        record.sub_domain = match record.sub_domain {
+            Some(sub_domain) if sub_domain.is_empty() => None,
+            x => x,
+        };
+
+        Ok(record)
+    }
+
+    /// Lists all DNS records
+    ///
+    /// This method will perform one extra API call per record
+    /// in order to get their details.
+    ///
+    /// ```no_run
+    /// use ovh::client::OvhClient;
+    /// use ovh::dns_record::OvhDnsRecord;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let c = OvhClient::from_conf("ovh.conf").unwrap();
+    ///     let records = OvhDnsRecord::list(&c, "example.com")
+    ///         .await
+    ///         .unwrap();
+    ///
+    ///     for r in records {
+    ///         println!("{}", r);
+    ///     }
+    /// }
+    /// ```
+    pub async fn list(
+        client: &OvhClient,
+        zone_name: &str,
+    ) -> Result<Vec<OvhDnsRecord>, Box<dyn std::error::Error>> {
+        let records = client
+            .get(&format!("/domain/zone/{}/record", zone_name))
+            .await?
+            .error_for_status()?
+            .json::<Vec<u64>>().await?
+            .into_iter()
+            .map(|id| Self::get_record(client, zone_name, id));
+
+        future::join_all(records)
+            .await
+            .into_iter()
+            .collect()
+    }
+}
+
+impl Display for OvhDnsRecord {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let domain = match &self.sub_domain {
+            Some(sub_domain) => format!("{}.{}.", sub_domain, self.zone),
+            None => format!("{}.", self.zone),
+        };
+        write!(f, "{} {} {:?} {}", domain, self.ttl.unwrap_or(0), self.field_type, self.target)
+    }
+}

--- a/src/dns_record.rs
+++ b/src/dns_record.rs
@@ -8,6 +8,7 @@ use reqwest::Response;
 use serde::{Deserialize, Serialize};
 
 use crate::client::OvhClient;
+use crate::client::Result;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub enum DnsRecordType {
@@ -86,11 +87,7 @@ impl OvhDnsRecord {
     }
 
     /// Retrieves a DNS record
-    async fn get_record(
-        client: &OvhClient,
-        zone_name: &str,
-        id: u64,
-    ) -> Result<OvhDnsRecord, Box<dyn std::error::Error>> {
+    async fn get_record(client: &OvhClient, zone_name: &str, id: u64) -> Result<OvhDnsRecord> {
         let mut record: OvhDnsRecord = client
             .get(&format!("/domain/zone/{}/record/{}", zone_name, id))
             .await?
@@ -127,10 +124,7 @@ impl OvhDnsRecord {
     ///     }
     /// }
     /// ```
-    pub async fn list(
-        client: &OvhClient,
-        zone: &str,
-    ) -> Result<Vec<OvhDnsRecord>, Box<dyn std::error::Error>> {
+    pub async fn list(client: &OvhClient, zone: &str) -> Result<Vec<OvhDnsRecord>> {
         Self::list_filtered(client, zone, None, None).await
     }
 
@@ -156,12 +150,7 @@ impl OvhDnsRecord {
     ///     }
     /// }
     /// ```
-    pub async fn list_filtered(
-        client: &OvhClient,
-        zone: &str,
-        record_type: Option<DnsRecordType>,
-        subdomain: Option<String>,
-    ) -> Result<Vec<OvhDnsRecord>, Box<dyn std::error::Error>> {
+    pub async fn list_filtered(client: &OvhClient, zone: &str, record_type: Option<DnsRecordType>, subdomain: Option<String>) -> Result<Vec<OvhDnsRecord>> {
         let mut options = Vec::with_capacity(2);
         if let Some(record_type) = record_type {
             options.push(format!("fieldType={:?}", record_type))

--- a/src/dns_record.rs
+++ b/src/dns_record.rs
@@ -121,7 +121,7 @@ impl OvhDnsRecord {
     ///
     /// #[tokio::main]
     /// async fn main() {
-    ///     let c = OvhClient::from_conf("ovh.conf").unwrap();
+    ///     let c = OvhClient::from_conf("ovh.conf").await.unwrap();
     ///     let record = OvhDnsRecord::get(&c, "example.com", 1234567)
     ///         .await
     ///         .unwrap();
@@ -149,7 +149,7 @@ impl OvhDnsRecord {
     ///
     /// #[tokio::main]
     /// async fn main() {
-    ///     let c = OvhClient::from_conf("ovh.conf").unwrap();
+    ///     let c = OvhClient::from_conf("ovh.conf").await.unwrap();
     ///     let ids = OvhDnsRecord::list_ids(&c, "example.com")
     ///         .await
     ///         .unwrap();
@@ -172,13 +172,13 @@ impl OvhDnsRecord {
     ///
     /// #[tokio::main]
     /// async fn main() {
-    ///     let c = OvhClient::from_conf("ovh.conf").unwrap();
-    ///     let records = OvhDnsRecord::list_ids_filtered(&c, "example.com", Some(DnsRecordType::TXT), Some("foo"))
+    ///     let c = OvhClient::from_conf("ovh.conf").await.unwrap();
+    ///     let ids = OvhDnsRecord::list_ids_filtered(&c, "example.com", Some(DnsRecordType::TXT), Some("foo"))
     ///         .await
     ///         .unwrap();
     ///
     ///     for id in ids {
-    ///         println!("{}", ids);
+    ///         println!("{}", id);
     ///	    }
     /// }
     /// ```
@@ -217,7 +217,7 @@ impl OvhDnsRecord {
     ///
     /// #[tokio::main]
     /// async fn main() {
-    ///     let c = OvhClient::from_conf("ovh.conf").unwrap();
+    ///     let c = OvhClient::from_conf("ovh.conf").await.unwrap();
     ///     let records = OvhDnsRecord::list(&c, "example.com")
     ///         .await
     ///         .unwrap();
@@ -243,7 +243,7 @@ impl OvhDnsRecord {
     ///
     /// #[tokio::main]
     /// async fn main() {
-    ///     let c = OvhClient::from_conf("ovh.conf").unwrap();
+    ///     let c = OvhClient::from_conf("ovh.conf").await.unwrap();
     ///     let records = OvhDnsRecord::list_filtered(&c, "example.com", Some(DnsRecordType::TXT), Some("foo"))
     ///         .await
     ///         .unwrap();
@@ -273,11 +273,11 @@ impl OvhDnsRecord {
     ///
     /// ```no_run
     /// use ovh::client::OvhClient;
-    /// use ovh::dns_record::OvhDnsRecord;
+    /// use ovh::dns_record::{DnsRecordType, OvhDnsRecord};
     ///
     /// #[tokio::main]
     /// async fn main() {
-    ///     let c = OvhClient::from_conf("ovh.conf").unwrap();
+    ///     let c = OvhClient::from_conf("ovh.conf").await.unwrap();
     ///     let record = OvhDnsRecord::create(&c, Some("www"), "example.com", DnsRecordType::A, Some(86400), "93.184.216.34", true)
     ///         .await
     ///         .unwrap();
@@ -312,7 +312,7 @@ impl OvhDnsRecord {
     ///
     /// #[tokio::main]
     /// async fn main() {
-    ///     let c = OvhClient::from_conf("ovh.conf").unwrap();
+    ///     let c = OvhClient::from_conf("ovh.conf").await.unwrap();
     ///     OvhDnsRecord::delete(&c, "example.com", 1234567, true)
     ///         .await
     ///         .unwrap();
@@ -338,7 +338,7 @@ impl OvhDnsRecord {
     ///
     /// #[tokio::main]
     /// async fn main() {
-    ///     let c = OvhClient::from_conf("ovh.conf").unwrap();
+    ///     let c = OvhClient::from_conf("ovh.conf").await.unwrap();
     ///     OvhDnsRecord::refresh_zone(&c, "example.com")
     ///         .await
     ///         .unwrap();

--- a/src/email_redir.rs
+++ b/src/email_redir.rs
@@ -4,6 +4,7 @@ use core::fmt;
 use std::fmt::Display;
 
 use crate::client::OvhClient;
+use crate::client::Result;
 use reqwest::Response;
 
 use serde::{Deserialize, Serialize};
@@ -21,11 +22,7 @@ pub struct OvhMailRedir {
 
 impl OvhMailRedir {
     /// Retrieves an email redirection entry.
-    async fn get_redir(
-        client: &OvhClient,
-        domain: &str,
-        id: &str,
-    ) -> Result<OvhMailRedir, Box<dyn std::error::Error>> {
+    async fn get_redir(client: &OvhClient, domain: &str, id: &str) -> Result<OvhMailRedir> {
         let res = client
             .get(&format!("/email/domain/{}/redirection/{}", domain, id))
             .await?
@@ -55,10 +52,7 @@ impl OvhMailRedir {
     ///     }
     /// }
     /// ```
-    pub async fn list(
-        client: &OvhClient,
-        domain: &str,
-    ) -> Result<Vec<OvhMailRedir>, Box<dyn std::error::Error>> {
+    pub async fn list(client: &OvhClient, domain: &str) -> Result<Vec<OvhMailRedir>> {
         let resp = client
             .get(&format!("/email/domain/{}/redirection", domain))
             .await?;
@@ -88,13 +82,7 @@ impl OvhMailRedir {
     ///         .unwrap();
     /// }
     /// ```
-    pub async fn create(
-        c: &OvhClient,
-        domain: &str,
-        from: &str,
-        to: &str,
-        local_copy: bool,
-    ) -> Result<Response, Box<dyn std::error::Error>> {
+    pub async fn create(c: &OvhClient, domain: &str, from: &str, to: &str, local_copy: bool) -> Result<Response> {
         let data = OvhMailRedirCreate {
             from,
             to,
@@ -118,11 +106,7 @@ impl OvhMailRedir {
     ///         .unwrap();
     /// }
     /// ```
-    pub async fn delete(
-        c: &OvhClient,
-        domain: &str,
-        id: &str,
-    ) -> Result<Response, Box<dyn std::error::Error>> {
+    pub async fn delete(c: &OvhClient, domain: &str, id: &str) -> Result<Response> {
         c.delete(&format!("/email/domain/{}/redirection/{}", domain, id))
             .await
     }

--- a/src/email_redir.rs
+++ b/src/email_redir.rs
@@ -42,7 +42,7 @@ impl OvhMailRedir {
     ///
     /// #[tokio::main]
     /// async fn main() {
-    ///     let c = OvhClient::from_conf("ovh.conf").unwrap();
+    ///     let c = OvhClient::from_conf("ovh.conf").await.unwrap();
     ///     let redirs = OvhMailRedir::list(&c, "example.com")
     ///         .await
     ///         .unwrap();
@@ -76,7 +76,7 @@ impl OvhMailRedir {
     ///
     /// #[tokio::main]
     /// async fn main() {
-    ///     let c = OvhClient::from_conf("ovh.conf").unwrap();
+    ///     let c = OvhClient::from_conf("ovh.conf").await.unwrap();
     ///     OvhMailRedir::create(&c, "example.com", "foo@example.com", "admin@example.com", false)
     ///         .await
     ///         .unwrap();
@@ -100,7 +100,7 @@ impl OvhMailRedir {
     ///
     /// #[tokio::main]
     /// async fn main() {
-    ///     let c = OvhClient::from_conf("ovh.conf").unwrap();
+    ///     let c = OvhClient::from_conf("ovh.conf").await.unwrap();
     ///     OvhMailRedir::delete(&c, "example.com", "1234567")
     ///         .await
     ///         .unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 //! Async client for the OVH API.
 
 pub mod client;
+pub mod dns_record;
 pub mod email_redir;


### PR DESCRIPTION
- Added high level function for DNS record API in `src/dns_record.rs`.
- Added `Result<T>` type [here](https://github.com/Cl00e9ment/rust-ovh/blob/3abec35758bb589a7b8ba39730328b690f5bc109/src/client.rs#L41) so function signatures are more concise. I modified them in `src/email_redir.rs`.
- Fixed https://github.com/MicroJoe/rust-ovh/issues/1
  The time delta is now computed in the client constructors. So now they are async (breaking change). I considered lazy-fetching the delta to not modify the constructors, but it would imply that `get`, `delete` and `post` methods has to mutate the client to store the result, which isn't great and is still a breaking change.