### PR TITLE
handle error with thiserror

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 phf = { version = "0.10", features = ["macros"] }
 configparser = "2.1.0"
+thiserror = "1.0"
 
 [dev-dependencies]
 clap = "3.0.0-beta.4"

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,5 +1,6 @@
 //! Low-level access to the OVH API.
 
+use crate::error::OvhError;
 use configparser::ini::Ini;
 use reqwest::{header::HeaderMap, Response};
 use serde::Serialize;
@@ -8,7 +9,6 @@ use std::{
     path::Path,
     time::{SystemTime, UNIX_EPOCH},
 };
-use crate::error::OvhError;
 
 // Private data
 
@@ -113,17 +113,21 @@ impl OvhClient {
         T: AsRef<Path>,
     {
         let mut conf = Ini::new();
-        conf.load(path).map_err(|e| OvhError::Generic(e))?;
+        conf.load(path).map_err(OvhError::Generic)?;
 
         let endpoint = conf
             .get("default", "endpoint")
             .ok_or(OvhError::Generic("missing key `endpoint`".to_owned()))?;
         let application_key = conf
             .get(&endpoint, "application_key")
-            .ok_or(OvhError::Generic("missing key `application_key`".to_owned()))?;
-        let application_secret = conf
-            .get(&endpoint, "application_secret")
-            .ok_or(OvhError::Generic("missing key `application_secret`".to_owned()))?;
+            .ok_or(OvhError::Generic(
+                "missing key `application_key`".to_owned(),
+            ))?;
+        let application_secret =
+            conf.get(&endpoint, "application_secret")
+                .ok_or(OvhError::Generic(
+                    "missing key `application_secret`".to_owned(),
+                ))?;
         let consumer_key = conf
             .get(&endpoint, "consumer_key")
             .ok_or(OvhError::Generic("missing key `consumer_key`".to_owned()))?;
@@ -162,9 +166,18 @@ impl OvhClient {
     /// local time, and then subtract it from the local time of the machine.
     /// The result is a time delta value, is seconds.
     pub async fn time_delta(&self) -> Result<i64, OvhError> {
-        let server_time: u64 = self.get_noauth("/auth/time").await?.text().await.map_err(|e| OvhError::Reqwest)?.parse().map_err(|e| OvhError::ParseIntError)?;
+        let server_time: u64 = self
+            .get_noauth("/auth/time")
+            .await?
+            .text()
+            .await
+            .map_err(OvhError::Reqwest)?
+            .parse()
+            .map_err(OvhError::ParseIntError)?;
 
-        let delta = (now() - server_time).try_into().map_err(|e| OvhError::TryFromInt)?;
+        let delta = (now() - server_time)
+            .try_into()
+            .map_err(OvhError::TryFromInt)?;
         Ok(delta)
     }
 
@@ -186,7 +199,7 @@ impl OvhClient {
         let mut headers = self.default_headers();
 
         let time_delta = self.time_delta().await?;
-        let now: i64 = now().try_into().map_err(|e| OvhError::TryFromInt)?;
+        let now: i64 = now().try_into().map_err(OvhError::TryFromInt)?;
         let timestamp = now + time_delta;
         let timestamp = timestamp.to_string();
 
@@ -204,19 +217,28 @@ impl OvhClient {
         let url = self.url(path);
         let headers = self.gen_headers(&url, "GET", "").await?;
 
-        let resp = self.client.get(url).headers(headers).send().await.map_err(|e| OvhError::Reqwest)?;
+        let resp = self
+            .client
+            .get(url)
+            .headers(headers)
+            .send()
+            .await
+            .map_err(OvhError::Reqwest)?;
         Ok(resp)
     }
 
     /// Performs a DELETE request.
-    pub async fn delete(
-        &self,
-        path: &str,
-    ) -> Result<reqwest::Response, OvhError> {
+    pub async fn delete(&self, path: &str) -> Result<reqwest::Response, OvhError> {
         let url = self.url(path);
         let headers = self.gen_headers(&url, "DELETE", "").await?;
 
-        let resp = self.client.delete(url).headers(headers).send().await.map_err(|e| OvhError::Reqwest)?;
+        let resp = self
+            .client
+            .delete(url)
+            .headers(headers)
+            .send()
+            .await
+            .map_err(OvhError::Reqwest)?;
         Ok(resp)
     }
 
@@ -230,7 +252,7 @@ impl OvhClient {
 
         // Cannot call RequestBuilder.json directly because of body
         // signature requirement.
-        let body = serde_json::to_string(data).map_err(|e| OvhError::Serde)?;
+        let body = serde_json::to_string(data).map_err(OvhError::Serde)?;
         let headers = self.gen_headers(&url, "POST", &body).await?;
 
         let resp = self
@@ -239,19 +261,23 @@ impl OvhClient {
             .headers(headers)
             .body(body)
             .send()
-            .await.map_err(|e| OvhError::Reqwest)?;
+            .await
+            .map_err(OvhError::Reqwest)?;
         Ok(resp)
     }
 
     /// Performs a GET request without auth.
-    pub async fn get_noauth(
-        &self,
-        path: &str,
-    ) -> Result<reqwest::Response, OvhError> {
+    pub async fn get_noauth(&self, path: &str) -> Result<reqwest::Response, OvhError> {
         let url = self.url(path);
         let headers = self.default_headers();
 
-        let resp = self.client.get(url).headers(headers).send().await.map_err(|e| OvhError::Reqwest)?;
+        let resp = self
+            .client
+            .get(url)
+            .headers(headers)
+            .send()
+            .await
+            .map_err(OvhError::Reqwest)?;
         Ok(resp)
     }
 }

--- a/src/email_redir.rs
+++ b/src/email_redir.rs
@@ -6,8 +6,8 @@ use std::fmt::Display;
 use crate::client::OvhClient;
 use reqwest::Response;
 
-use serde::{Deserialize, Serialize};
 use crate::error::OvhError;
+use serde::{Deserialize, Serialize};
 
 /// Structure representing a single email redirection.
 #[derive(Debug, Deserialize)]
@@ -31,7 +31,8 @@ impl OvhMailRedir {
             .get(&format!("/email/domain/{}/redirection/{}", domain, id))
             .await?
             .json()
-            .await.map_err(|e| OvhError::Reqwest)?;
+            .await
+            .map_err(OvhError::Reqwest)?;
         Ok(res)
     }
 
@@ -56,16 +57,16 @@ impl OvhMailRedir {
     ///     }
     /// }
     /// ```
-    pub async fn list(
-        client: &OvhClient,
-        domain: &str,
-    ) -> Result<Vec<OvhMailRedir>, OvhError> {
+    pub async fn list(client: &OvhClient, domain: &str) -> Result<Vec<OvhMailRedir>, OvhError> {
         let resp = client
             .get(&format!("/email/domain/{}/redirection", domain))
             .await?;
-        let resp = resp.error_for_status().map_err(|e| OvhError::Reqwest)?;
+        let resp = resp.error_for_status().map_err(OvhError::Reqwest)?;
 
-        let res = resp.json::<Vec<String>>().await.map_err(|e| OvhError::Reqwest)?;
+        let res = resp
+            .json::<Vec<String>>()
+            .await
+            .map_err(OvhError::Reqwest)?;
         let res: Vec<_> =
             futures::future::join_all(res.iter().map(|id| Self::get_redir(client, domain, id)))
                 .await;
@@ -119,11 +120,7 @@ impl OvhMailRedir {
     ///         .unwrap();
     /// }
     /// ```
-    pub async fn delete(
-        c: &OvhClient,
-        domain: &str,
-        id: &str,
-    ) -> Result<Response, OvhError> {
+    pub async fn delete(c: &OvhClient, domain: &str, id: &str) -> Result<Response, OvhError> {
         c.delete(&format!("/email/domain/{}/redirection/{}", domain, id))
             .await
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,23 +1,22 @@
+use reqwest::Error as ReqError;
+use serde_json::Error as SerError;
+use std::num::{ParseIntError, TryFromIntError};
 use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum OvhError {
-
     #[error("network issue")]
-    Reqwest,
+    Reqwest(#[from] ReqError),
 
     #[error("parseInt issue")]
-    ParseIntError,
+    ParseIntError(#[from] ParseIntError),
 
     #[error("tryFromInt issue")]
-    TryFromInt,
+    TryFromInt(#[from] TryFromIntError),
 
     #[error("serde issue")]
-    Serde,
+    Serde(#[from] SerError),
 
     #[error("generic error : `{0}`")]
     Generic(String),
-
-    #[error("unknown data store error")]
-    Unknown,
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,23 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum OvhError {
+
+    #[error("network issue")]
+    Reqwest,
+
+    #[error("parseInt issue")]
+    ParseIntError,
+
+    #[error("tryFromInt issue")]
+    TryFromInt,
+
+    #[error("serde issue")]
+    Serde,
+
+    #[error("generic error : `{0}`")]
+    Generic(String),
+
+    #[error("unknown data store error")]
+    Unknown,
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,3 +2,4 @@
 
 pub mod client;
 pub mod email_redir;
+pub mod error;


### PR DESCRIPTION
When trying to use this repository into async code, i got error about the error not being `send` 

I have wrap all the error with thiserror, they are now usable into a async context and if necessay a match could be done to retry some network issues.

I pass cargo fmt and cargo clippy.